### PR TITLE
Add matched route to Curveball context

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,31 @@ const route = router(
 app.use(route);
 ```
 
+Access matched route in other middleware
+---------------
+The matched route is added into the Curveball context for other middleware to access
+if they need (such as for access request logging). It will be accessible after the
+router has executed.
+
+```typescript
+import { Application, Context } from '@curveball/core';
+import router from '@curveball/router';
+
+const app = Application();
+app.use(async (ctx: Context, next) => {
+  await next();
+
+  // Will be '/foo/:id'
+  const matchedRoute = ctx.router?.matchedRoute;
+});
+
+app.use(
+  router('/foo/:id', ctx => {
+    ctx.response.body = '/foo/' + ctx.state.params.id;
+  });
+);
+```
+
+
 [1]: https://github.com/curveball/
 [2]: https://github.com/koajs/path-match

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,11 @@
         "ts-node": "^10.8.1",
         "typescript": "^4.1.3"
       },
+      "engines": {
+        "node": ">= 14"
+      },
       "peerDependencies": {
-        "@curveball/core": ">=0.16 <1"
+        "@curveball/core": ">=0.19 <1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -4,7 +4,7 @@ declare module '@curveball/core' {
 
   interface Context {
     params: Record<string, string>;
-    router: {
+    router?: {
       matchedRoute: string;
     };
   }

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -4,6 +4,9 @@ declare module '@curveball/core' {
 
   interface Context {
     params: Record<string, string>;
+    router: {
+      matchedRoute: string;
+    };
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ function anyMethodRoute(path: string, ...middlewares: Middleware[]): Middleware 
     // This is deprecated
     ctx.state.params = result.params;
 
+    ctx.router = {
+      matchedRoute: path
+    };
+
     return invokeMiddlewares(
       ctx,
       [
@@ -77,6 +81,9 @@ function methodRoute(path: string): Dispatcher {
     // This is deprecated
     ctx.state.params = result.params;
 
+    ctx.router = {
+      matchedRoute: path
+    };
 
     if (perMethodMws[ctx.method] === undefined || perMethodMws[ctx.method].length === 0) {
       throw new MethodNotAllowed();

--- a/test/method-route.ts
+++ b/test/method-route.ts
@@ -74,4 +74,21 @@ describe('method-based routes', async () => {
 
   });
 
+  it('should add the matched route to the context', async() => {
+
+    let matchedRoute = '';
+    const app2 = new Application();
+    app2.use(router('/foo/:id')
+      .get( ctx => {
+        matchedRoute = ctx.router.matchedRoute;
+        ctx.response.body = 'GET /foo/' + ctx.state.params.id;
+
+      })
+    );
+    const response = await app2.subRequest('GET', '/foo/1');
+    expect(response.body).to.equal('GET /foo/1');
+    expect(matchedRoute).to.equal('/foo/:id');
+
+  });
+
 });

--- a/test/method-route.ts
+++ b/test/method-route.ts
@@ -76,11 +76,11 @@ describe('method-based routes', async () => {
 
   it('should add the matched route to the context', async() => {
 
-    let matchedRoute = '';
+    let matchedRoute;
     const app2 = new Application();
     app2.use(router('/foo/:id')
       .get( ctx => {
-        matchedRoute = ctx.router.matchedRoute;
+        matchedRoute = ctx.router?.matchedRoute;
         ctx.response.body = 'GET /foo/' + ctx.state.params.id;
 
       })

--- a/test/simple-route.ts
+++ b/test/simple-route.ts
@@ -61,4 +61,21 @@ describe('simple routes', async () => {
 
   });
 
+  it('should add the matched route to the context', async () => {
+
+    let matchedRoute = '';
+    const app = new Application();
+    app.use(router('/foo/:id',
+      (ctx, next) => next(),
+      ctx => {
+        matchedRoute = ctx.router.matchedRoute;
+        ctx.response.body = 'Hello world';
+      }
+    ));
+    const response = await app.subRequest('GET', '/foo/1');
+    expect(response.body).to.equal('Hello world');
+    expect(matchedRoute).to.equal('/foo/:id');
+
+  });
+
 });

--- a/test/simple-route.ts
+++ b/test/simple-route.ts
@@ -63,12 +63,12 @@ describe('simple routes', async () => {
 
   it('should add the matched route to the context', async () => {
 
-    let matchedRoute = '';
+    let matchedRoute;
     const app = new Application();
     app.use(router('/foo/:id',
       (ctx, next) => next(),
       ctx => {
-        matchedRoute = ctx.router.matchedRoute;
+        matchedRoute = ctx.router?.matchedRoute;
         ctx.response.body = 'Hello world';
       }
     ));


### PR DESCRIPTION
Save the matched route into Curveball's context for upstream middleware to access. The specific use case I have in mind is for request logging so requests can be grouped by matched route.

`package-log.json` was automagically updated when I `npm install`ed everything. It looks like it was updated to match `package.json`.